### PR TITLE
Fix wrong file enumeration in goverVersionFrom:

### DIFF
--- a/MonticelloTonel-Core.package/TonelRepository.class/instance/goferVersionFrom..st
+++ b/MonticelloTonel-Core.package/TonelRepository.class/instance/goferVersionFrom..st
@@ -2,9 +2,9 @@ metacello support
 goferVersionFrom: aVersionReference
 	"Simillar hack than FileTree repositories."
 
-	(self readableFileNames collect: [ :fileName | self fileDirectoryOn: fileName ])
-		do: [ :packageDirectory |
-			((self fileUtils directoryExists: packageDirectory )
-			and: [(self versionInfoForPackageDirectory: packageDirectory) name = aVersionReference name])
-				ifTrue: [ ^ self loadVersionFromFileNamed: (self fileUtils directoryName: packageDirectory) ] ].
-	^nil
+	((self directory entries select: [:entry | entry isDirectory and: [self canReadFileNamed: entry name]] thenCollect: [ :entry | self fileDirectoryOn: entry name ])
+		select: [ :packageDirectory | self fileUtils directoryExists: packageDirectory ])
+        do: [ :packageDirectory | 
+            (self versionInfoForPackageDirectory: packageDirectory) name = aVersionReference name
+                ifTrue: [ ^ self loadVersionFromFileNamed: (self fileUtils directoryName: packageDirectory) ] ].
+    ^ nil

--- a/MonticelloTonel-Core.package/TonelRepository.class/methodProperties.json
+++ b/MonticelloTonel-Core.package/TonelRepository.class/methodProperties.json
@@ -21,7 +21,7 @@
 		"fileNameFromDirectory:" : "jr 1/2/2019 00:49",
 		"fileUtils" : "12/9/2018 20:41:24",
 		"filterFileNames:forVersionNamed:" : "12/9/2018 20:41:24",
-		"goferVersionFrom:" : "12/9/2018 20:41:24",
+		"goferVersionFrom:" : "tobe 5/6/2020 20:44",
 		"loadAllFileNames" : "12/9/2018 20:41:24",
 		"packageDescriptionFromPackageDirectory:" : "12/9/2018 20:41:24",
 		"packageDescriptionsFromReadableFileNames" : "12/9/2018 20:41:24",

--- a/MonticelloTonel-Tests.package/TonelRepositoryTest.class/instance/testGoferVersion.st
+++ b/MonticelloTonel-Tests.package/TonelRepositoryTest.class/instance/testGoferVersion.st
@@ -1,0 +1,7 @@
+tests
+testGoferVersion
+	| mem |
+	
+	mem := self newMemoryFileSystem.
+	repository := TonelRepository new directory: mem.
+	self assert: (repository goferVersionFrom: (GoferReference name: 'Tests-MonticelloMocks-tonel.1')) notNil

--- a/MonticelloTonel-Tests.package/TonelRepositoryTest.class/methodProperties.json
+++ b/MonticelloTonel-Tests.package/TonelRepositoryTest.class/methodProperties.json
@@ -6,6 +6,7 @@
 		"newMemoryFileSystem" : "12/9/2018 20:41:24",
 		"setUp" : "12/9/2018 20:41:24",
 		"testCanCreateTonelRepositoryFromUrl" : "jr 12/9/2018 19:43",
+		"testGoferVersion" : "tobe 5/6/2020 22:44",
 		"testLoadAllFileNames" : "TonelRepositoryTest 1/2/2019 00:51",
 		"testReadableFileNames" : "jr 1/2/2019 21:13",
 		"testVersionFromFileName" : "jr 1/2/2019 22:00" } }


### PR DESCRIPTION
I'm not entirely sure if `readableFileNames` is doing the correct thing at all, it currently appears to work though, so I adapted `goferVersionFrom:` instead to mirror the call in FileTree.